### PR TITLE
Update canary and demos for 0.17.0 release

### DIFF
--- a/.github/workflows/canary-centos.yml
+++ b/.github/workflows/canary-centos.yml
@@ -19,6 +19,10 @@ on:
         description: 'djl version to test'
         required: false
         default: '0.16.0'
+      pt-version:
+        description: 'pytorch version to test'
+        required: false
+        default: ''
 
 jobs:
   canary-test-centos:
@@ -28,6 +32,7 @@ jobs:
       AWS_REGION: us-east-1
       DJL_STAGING: ${{github.event.inputs.repo-id}}
       DJL_VERSION: ${{github.event.inputs.djl-version}}
+      PT_VERSION: ${{github.event.inputs.pt-version}}
     container: centos:7
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/canary-centos.yml
+++ b/.github/workflows/canary-centos.yml
@@ -18,7 +18,7 @@ on:
       djl-version:
         description: 'djl version to test'
         required: false
-        default: '0.16.0'
+        default: '0.17.0'
       pt-version:
         description: 'pytorch version to test'
         required: false

--- a/.github/workflows/canary-mac.yml
+++ b/.github/workflows/canary-mac.yml
@@ -12,7 +12,7 @@ on:
       djl-version:
         description: 'djl version to test'
         required: false
-        default: '0.16.0'
+        default: '0.17.0'
       pt-version:
         description: 'pytorch version to test'
         required: false

--- a/.github/workflows/canary-mac.yml
+++ b/.github/workflows/canary-mac.yml
@@ -13,6 +13,10 @@ on:
         description: 'djl version to test'
         required: false
         default: '0.16.0'
+      pt-version:
+        description: 'pytorch version to test'
+        required: false
+        default: ''
 
 jobs:
   canary-test-mac:
@@ -22,6 +26,7 @@ jobs:
       AWS_REGION: us-east-1
       DJL_STAGING: ${{github.event.inputs.repo-id}}
       DJL_VERSION: ${{github.event.inputs.djl-version}}
+      PT_VERSION: ${{github.event.inputs.pt-version}}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -36,19 +41,23 @@ jobs:
           DJL_ENGINE=mxnet-native-mkl ./gradlew clean run
           rm -rf ~/.djl.ai
       - name: Test PyTorch
+        working-directory: canary
         run: |
-          cd canary
           DJL_ENGINE=pytorch-native-auto ./gradlew clean run
-          rm -rf ~/.djl.ai
-          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.8.1 ./gradlew clean run
           rm -rf ~/.djl.ai
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.9.1 ./gradlew clean run
           rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.11.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
           DJL_ENGINE=pytorch-native-cpu ./gradlew clean run
           rm -rf ~/.djl.ai
-          DJL_ENGINE=pytorch-native-cpu PT_VERSION=1.8.1 ./gradlew clean run
-          rm -rf ~/.djl.ai
           DJL_ENGINE=pytorch-native-cpu PT_VERSION=1.9.1 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu PT_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu PT_VERSION=1.11.0 ./gradlew clean run
           rm -rf ~/.djl.ai
       - name: Test TensorFlow
         run: |

--- a/.github/workflows/canary-ubuntu.yml
+++ b/.github/workflows/canary-ubuntu.yml
@@ -13,6 +13,10 @@ on:
         description: 'djl version to test'
         required: false
         default: '0.16.0'
+      pt-version:
+        description: 'pytorch version to test'
+        required: false
+        default: ''
 
 jobs:
   canary-test-ubuntu:
@@ -25,6 +29,7 @@ jobs:
       AWS_REGION: us-east-1
       DJL_STAGING: ${{github.event.inputs.repo-id}}
       DJL_VERSION: ${{github.event.inputs.djl-version}}
+      PT_VERSION: ${{github.event.inputs.pt-version}}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -47,15 +52,19 @@ jobs:
         run: |
           DJL_ENGINE=pytorch-native-auto ./gradlew clean run
           rm -rf ~/.djl.ai
-          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.8.1 ./gradlew clean run
-          rm -rf ~/.djl.ai
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.9.1 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.11.0 ./gradlew clean run
           rm -rf ~/.djl.ai
           DJL_ENGINE=pytorch-native-cpu ./gradlew clean run
           rm -rf ~/.djl.ai
-          DJL_ENGINE=pytorch-native-cpu PT_VERSION=1.8.1 ./gradlew clean run
-          rm -rf ~/.djl.ai
           DJL_ENGINE=pytorch-native-cpu PT_VERSION=1.9.1 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu PT_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu PT_VERSION=1.11.0 ./gradlew clean run
           rm -rf ~/.djl.ai
       - name: Test TensorFlow
         working-directory: canary

--- a/.github/workflows/canary-ubuntu.yml
+++ b/.github/workflows/canary-ubuntu.yml
@@ -12,7 +12,7 @@ on:
       djl-version:
         description: 'djl version to test'
         required: false
-        default: '0.16.0'
+        default: '0.17.0'
       pt-version:
         description: 'pytorch version to test'
         required: false

--- a/.github/workflows/canary-windows.yml
+++ b/.github/workflows/canary-windows.yml
@@ -13,6 +13,10 @@ on:
         description: 'djl version to test'
         required: false
         default: '0.16.0'
+      pt-version:
+        description: 'pytorch version to test'
+        required: false
+        default: ''
 
 jobs:
   canary-test-windows:
@@ -22,6 +26,7 @@ jobs:
       AWS_REGION: us-east-1
       DJL_STAGING: ${{github.event.inputs.repo-id}}
       DJL_VERSION: ${{github.event.inputs.djl-version}}
+      PT_VERSION: ${{github.event.inputs.pt-version}}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -40,15 +45,20 @@ jobs:
         run: |
           cmd /c "set DJL_ENGINE=pytorch-native-auto&& .\gradlew.bat clean run"
           cmd /c "rd /s /q %userprofile%\.djl.ai"
-          cmd /c "set DJL_ENGINE=pytorch-native-auto&& set PYTORCH_VERSION=1.8.1&& .\gradlew.bat clean run"
-          cmd /c "rd /s /q %userprofile%\.djl.ai"
           cmd /c "set DJL_ENGINE=pytorch-native-auto&& set PYTORCH_VERSION=1.9.1&& .\gradlew.bat clean run"
+          cmd /c "rd /s /q %userprofile%\.djl.ai"
+          cmd /c "set DJL_ENGINE=pytorch-native-auto&& set PYTORCH_VERSION=1.10.0&& .\gradlew.bat clean run"
+          cmd /c "rd /s /q %userprofile%\.djl.ai"
+          cmd /c "set DJL_ENGINE=pytorch-native-auto&& set PYTORCH_VERSION=1.11.0&& .\gradlew.bat clean run"
           cmd /c "rd /s /q %userprofile%\.djl.ai"
           cmd /c "set DJL_ENGINE=pytorch-native-cpu&& .\gradlew.bat clean run"
           cmd /c "rd /s /q %userprofile%\.djl.ai"
-          cmd /c "set DJL_ENGINE=pytorch-native-cpu&& set PT_VERSION=1.8.1&& .\gradlew.bat clean run"
-          cmd /c "rd /s /q %userprofile%\.djl.ai"
           cmd /c "set DJL_ENGINE=pytorch-native-cpu&& set PT_VERSION=1.9.1&& .\gradlew.bat clean run"
+          cmd /c "rd /s /q %userprofile%\.djl.ai"
+          cmd /c "set DJL_ENGINE=pytorch-native-cpu&& set PT_VERSION=1.10.0&& .\gradlew.bat clean run"
+          cmd /c "rd /s /q %userprofile%\.djl.ai"
+          cmd /c "set DJL_ENGINE=pytorch-native-cpu&& set PT_VERSION=1.11.0&& .\gradlew.bat clean run"
+          cmd /c "rd /s /q %userprofile%\.djl.ai"
       - name: Test TensorFlow
         working-directory: canary
         run: |

--- a/.github/workflows/canary-windows.yml
+++ b/.github/workflows/canary-windows.yml
@@ -12,7 +12,7 @@ on:
       djl-version:
         description: 'djl version to test'
         required: false
-        default: '0.16.0'
+        default: '0.17.0'
       pt-version:
         description: 'pytorch version to test'
         required: false

--- a/aws/beanstalk-model-serving/build.gradle
+++ b/aws/beanstalk-model-serving/build.gradle
@@ -15,9 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation platform("ai.djl:bom:0.14.0")
+    implementation platform("ai.djl:bom:0.17.0")
     implementation "ai.djl.pytorch:pytorch-model-zoo"
-    implementation "ai.djl.pytorch:pytorch-native-auto"
 
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/canary/build.gradle
+++ b/canary/build.gradle
@@ -10,7 +10,7 @@ def djlVersion = getEnv("DJL_VERSION", "0.16.0")
 def engine = getEnv("DJL_ENGINE", "mxnet-native-auto")
 def os = getOsName()
 def stagingRepo = getEnv("DJL_STAGING", null)
-def ptVersion = getEnv("PT_VERSION", "1.10.0")
+def ptVersion = getEnv("PT_VERSION", "1.11.0")
 
 repositories {
     mavenCentral()

--- a/canary/build.gradle
+++ b/canary/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group "com.example"
 version "1.0-SNAPSHOT"
 
-def djlVersion = getEnv("DJL_VERSION", "0.16.0")
+def djlVersion = getEnv("DJL_VERSION", "0.17.0")
 def engine = getEnv("DJL_ENGINE", "mxnet-native-auto")
 def os = getOsName()
 def stagingRepo = getEnv("DJL_STAGING", null)

--- a/developement/fatjar/build.gradle
+++ b/developement/fatjar/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform("ai.djl:bom:0.16.0")
+    implementation platform("ai.djl:bom:0.17.0")
     implementation "ai.djl:api"
 
     runtimeOnly "ai.djl.pytorch:pytorch-model-zoo"

--- a/developement/fatjar/pom.xml
+++ b/developement/fatjar/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <djl.version>0.16.0</djl.version>
+        <djl.version>0.17.0</djl.version>
         <exec.mainClass>com.examples.FatJar</exec.mainClass>
     </properties>
 

--- a/developement/module/build.gradle
+++ b/developement/module/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group "org.examples"
 version "1.0-SNAPSHOT"
 
-def djlVersion = "0.16.0"
+def djlVersion = "0.17.0"
 
 repositories {
     mavenCentral()

--- a/developement/multi-engine/build.gradle
+++ b/developement/multi-engine/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform("ai.djl:bom:0.16.0")
+    implementation platform("ai.djl:bom:0.17.0")
     implementation "ai.djl:api"
 
     runtimeOnly "ai.djl.pytorch:pytorch-model-zoo"

--- a/huggingface/hybrid/build.gradle
+++ b/huggingface/hybrid/build.gradle
@@ -15,11 +15,10 @@ repositories {
 }
 
 dependencies {
-    implementation platform("ai.djl:bom:0.14.0-SNAPSHOT")
+    implementation platform("ai.djl:bom:0.17.0")
     implementation "ai.djl:api"
 
     runtimeOnly "ai.djl.pytorch:pytorch-model-zoo"
-    runtimeOnly "ai.djl.pytorch:pytorch-native-auto"
     runtimeOnly "ai.djl.python:python"
 
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.17.1"

--- a/web-demo/interactive-console/build.gradle
+++ b/web-demo/interactive-console/build.gradle
@@ -19,15 +19,12 @@ configure(this) {
 }
 
 dependencies {
-	implementation platform("ai.djl:bom:0.14.0")
+	implementation platform("ai.djl:bom:0.17.0")
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly "ai.djl:api"
 	runtimeOnly "ai.djl.pytorch:pytorch-model-zoo"
-	runtimeOnly "ai.djl.pytorch:pytorch-native-auto"
 	runtimeOnly "ai.djl.mxnet:mxnet-model-zoo"
-	runtimeOnly "ai.djl.mxnet:mxnet-native-auto"
 	runtimeOnly "ai.djl.tensorflow:tensorflow-model-zoo"
-	runtimeOnly "ai.djl.tensorflow:tensorflow-native-auto"
 }
 

--- a/web-demo/interactive-console/src/main/resources/starter/mxnet.gradle
+++ b/web-demo/interactive-console/src/main/resources/starter/mxnet.gradle
@@ -11,8 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform("ai.djl:bom:0.14.0")
+    implementation platform("ai.djl:bom:0.17.0")
     implementation "ai.djl:api"
     runtimeOnly "ai.djl.mxnet:mxnet-model-zoo"
-    runtimeOnly "ai.djl.mxnet:mxnet-native-auto"
 }

--- a/web-demo/interactive-console/src/main/resources/starter/pytorch.gradle
+++ b/web-demo/interactive-console/src/main/resources/starter/pytorch.gradle
@@ -11,8 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform("ai.djl:bom:0.14.0")
+    implementation platform("ai.djl:bom:0.17.0")
     implementation "ai.djl:api"
     runtimeOnly "ai.djl.pytorch:pytorch-model-zoo"
-    runtimeOnly "ai.djl.pytorch:pytorch-native-auto"
 }

--- a/web-demo/interactive-console/src/main/resources/starter/tensorflow.gradle
+++ b/web-demo/interactive-console/src/main/resources/starter/tensorflow.gradle
@@ -11,8 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform("ai.djl:bom:0.14.0")
+    implementation platform("ai.djl:bom:0.17.0")
     implementation "ai.djl:api"
     runtimeOnly "ai.djl.tensorflow:tensorflow-model-zoo"
-    runtimeOnly "ai.djl.tensorflow:tensorflow-native-auto"
 }


### PR DESCRIPTION
This also adds an option to run canaries with a specific pytorch version.