### PR TITLE
Add gpu canary builds

### DIFF
--- a/.github/workflows/canary-gpu-cuda-102.yml
+++ b/.github/workflows/canary-gpu-cuda-102.yml
@@ -1,0 +1,115 @@
+name: Canary-GPU-Cuda-102
+
+on:
+  schedule:
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+    inputs:
+      repo-id:
+        description: 'staging repository id to test'
+        required: false
+        default: ''
+      djl-version:
+        description: 'djl version to test'
+        required: false
+        default: '0.18.0'
+      pt-version:
+        description: 'pytorch version to test'
+        required: false
+        default: ''
+
+jobs:
+  canary-test-cuda102:
+    if: github.repository == 'deepjavalibrary/djl-demo'
+    runs-on: [ self-hosted, gpu ]
+    container:
+      image: nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04
+      options: --gpus all --runtime=nvidia
+    timeout-minutes: 30
+    needs: create-gpu-runner
+    steps:
+      - name: Setup Environment
+        run: |
+          apt-get update
+          apt-get install -y software-properties-common wget
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: corretto
+      - name: Test MXNet
+        working-directory: canary
+        run: |
+          DJL_ENGINE=mxnet-native-auto ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=mxnet-native-mkl ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=mxnet-native-cu102mkl ./gradlew clean run
+          rm -rf ~/.djl.ai
+      - name: Test PyTorch
+        working-directory: canary
+        run: |
+          DJL_ENGINE=pytorch-native-auto ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.9.1 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=1.9.1 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu-precxx11 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cu102 ./gradlew clean run
+          rm -rf ~/.djl.ai
+      - name: Test Tensorflow
+        working-directory: canary
+        run: |
+          DJL_ENGINE=tensorflow-native-cpu ./gradlew clean run
+          rm -rf ~/.djl.ai
+      - name: Test Paddle
+        working-directory: canary
+        run: |
+          mkdir -p ~/.djl.ai/paddle/2.2.2-cu102-linux-x86_64
+          DJL_CACHE_DIR=~/.djl.ai DJL_ENGINE=paddlepaddle-native-auto \
+          LD_LIBRARY_PATH=$DJL_CACHE_DIR/paddle/2.2.2-cu102-linux-x86_64 \
+          ./gradlew clean run
+          rm -rf ~/.djl.ai
+          mkdir -p ~/.djl.ai/paddle/2.2.2-20220429-cu102-linux-x86_64
+          DJL_CACHE_DIR=~/.djl.ai DJL_ENGINE=paddlepaddle-native-cu102 \
+          LD_LIBRARY_PATH=$DJL_CACHE_DIR/paddle/2.2.2-20220429-cu102-linux-x86_64 \
+          ./gradlew clean run
+          rm -rf ~/.djl.ai
+
+  create-gpu-runner:
+    if: github.repository == 'deepjavalibrary/djl-demo'
+    runs-on: [ self-hosted, scheduler ]
+    steps:
+      - name: Create new GPU instance
+        id: create_gpu
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          token=$( curl -X POST -H "Authorization: token ${{ secrets.ACTION_RUNNER_PERSONAL_TOKEN }}" \
+          https://api.github.com/repos/deepjavalibrary/djl-demo/actions/runners/registration-token \
+          --fail \
+          | jq '.token' | tr -d '"' )
+          ./start_instance.sh action_gpu $token djl-demo
+    outputs:
+      gpu_instance_id: ${{ steps.create_gpu.outputs.action_gpu_instance_id }}
+
+  stop-runners:
+    if: always()
+    runs-on: [ self-hosted, scheduler ]
+    needs: [ create-gpu-runner, canary-test-cuda102 ]
+    steps:
+      - name: Stop all instances
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          instance_id=${{ needs.create-gpu-runner.outputs.gpu_instance_id }}
+          ./stop_instance.sh $instance_id

--- a/.github/workflows/canary-gpu-cuda-112.yml
+++ b/.github/workflows/canary-gpu-cuda-112.yml
@@ -1,0 +1,119 @@
+name: Canary-GPU-Cuda-112
+
+on:
+  schedule:
+    - cron: '0 22 * * *'
+  workflow_dispatch:
+    inputs:
+      repo-id:
+        description: 'staging repository id to test'
+        required: false
+        default: ''
+      djl-version:
+        description: 'djl version to test'
+        required: false
+        default: '0.18.0'
+      pt-version:
+        description: 'pytorch version to test'
+        required: false
+        default: ''
+
+jobs:
+  canary-test-cuda112:
+    if: github.repository == 'deepjavalibrary/djl-demo'
+    runs-on: [ self-hosted, gpu ]
+    container:
+      image: nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu18.04
+      options: --gpus all --runtime=nvidia
+    timeout-minutes: 30
+    needs: create-gpu-runner
+    steps:
+      - name: Setup Environment
+        run: |
+          apt-get update
+          apt-get install -y software-properties-common wget
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: corretto
+      - name: Test MXNet
+        working-directory: canary
+        run: |
+          DJL_ENGINE=mxnet-native-auto ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=mxnet-native-mkl ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=mxnet-native-cu112mkl ./gradlew clean run
+          rm -rf ~/.djl.ai
+      - name: Test PyTorch
+        working-directory: canary
+        run: |
+          DJL_ENGINE=pytorch-native-auto ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.9.1 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=1.9.1 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu-precxx11 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cu113 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cu113-precxx11 ./gradlew clean run
+          rm -rf ~/.djl.ai
+      - name: Test Tensorflow
+        working-directory: canary
+        run: |
+          DJL_ENGINE=tensorflow-native-cpu ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=tensorflow-native-cu113 ./gradlew clean run
+          rm -rf ~/.djl.ai
+      - name: Test Paddle
+        working-directory: canary
+        run: |
+          mkdir -p ~/.djl.ai/paddle/2.2.2-cu112-linux-x86_64
+          DJL_CACHE_DIR=~/.djl.ai DJL_ENGINE=paddlepaddle-native-auto \
+          LD_LIBRARY_PATH=$DJL_CACHE_DIR/paddle/2.2.2-cu112-linux-x86_64 \
+          ./gradlew clean run
+          rm -rf ~/.djl.ai
+          mkdir -p ~/.djl.ai/paddle/2.2.2-20220429-cu112-linux-x86_64
+          DJL_CACHE_DIR=~/.djl.ai DJL_ENGINE=paddlepaddle-native-cu112 \
+          LD_LIBRARY_PATH=$DJL_CACHE_DIR/paddle/2.2.2-20220429-cu112-linux-x86_64 \
+          ./gradlew clean run
+          rm -rf ~/.djl.ai
+
+  create-gpu-runner:
+    if: github.repository == 'deepjavalibrary/djl-demo'
+    runs-on: [ self-hosted, scheduler ]
+    steps:
+      - name: Create new GPU instance
+        id: create_gpu
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          token=$( curl -X POST -H "Authorization: token ${{ secrets.ACTION_RUNNER_PERSONAL_TOKEN }}" \
+          https://api.github.com/repos/deepjavalibrary/djl-demo/actions/runners/registration-token \
+          --fail \
+          | jq '.token' | tr -d '"' )
+          ./start_instance.sh action_gpu $token djl-demo
+    outputs:
+      gpu_instance_id: ${{ steps.create_gpu.outputs.action_gpu_instance_id }}
+
+  stop-runners:
+    if: always()
+    runs-on: [ self-hosted, scheduler ]
+    needs: [ create-gpu-runner, canary-test-cuda112 ]
+    steps:
+      - name: Stop all instances
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          instance_id=${{ needs.create-gpu-runner.outputs.gpu_instance_id }}
+          ./stop_instance.sh $instance_id

--- a/.github/workflows/canary-gpu-cuda-113.yml
+++ b/.github/workflows/canary-gpu-cuda-113.yml
@@ -1,0 +1,113 @@
+name: Canary-GPU-Cuda-113
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      repo-id:
+        description: 'staging repository id to test'
+        required: false
+        default: ''
+      djl-version:
+        description: 'djl version to test'
+        required: false
+        default: '0.18.0'
+      pt-version:
+        description: 'pytorch version to test'
+        required: false
+        default: ''
+
+jobs:
+  canary-test-cuda113:
+    if: github.repository == 'deepjavalibrary/djl-demo'
+    runs-on: [ self-hosted, gpu ]
+    container:
+      image: nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu18.04
+      options: --gpus all --runtime=nvidia
+    timeout-minutes: 30
+    needs: create-gpu-runner
+    steps:
+      - name: Setup Environment
+        run: |
+          apt-get update
+          apt-get install -y software-properties-common wget
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: corretto
+      - name: Test MXNet
+        working-directory: canary
+        run: |
+          DJL_ENGINE=mxnet-native-auto ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=mxnet-native-mkl ./gradlew clean run
+          rm -rf ~/.djl.ai
+      - name: Test PyTorch
+        working-directory: canary
+        run: |
+          DJL_ENGINE=pytorch-native-auto ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.9.1 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=1.9.1 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=1.10.0 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cpu-precxx11 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cu113 ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=pytorch-native-cu113-precxx11 ./gradlew clean run
+          rm -rf ~/.djl.ai
+      - name: Test Tensorflow
+        working-directory: canary
+        run: |
+          DJL_ENGINE=tensorflow-native-auto ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=tensorflow-native-cpu ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=tensorflow-native-cu113 ./gradlew clean run
+          rm -rf ~/.djl.ai
+      - name: Test Paddle
+        working-directory: canary
+        run: |
+          DJL_ENGINE=paddlepaddle-native-auto ./gradlew clean run
+          rm -rf ~/.djl.ai
+          DJL_ENGINE=paddlepaddle-native-cpu ./gradlew clean run
+          rm -rf ~/.djl.ai
+
+  create-gpu-runner:
+    if: github.repository == 'deepjavalibrary/djl-demo'
+    runs-on: [ self-hosted, scheduler ]
+    steps:
+      - name: Create new GPU instance
+        id: create_gpu
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          token=$( curl -X POST -H "Authorization: token ${{ secrets.ACTION_RUNNER_PERSONAL_TOKEN }}" \
+          https://api.github.com/repos/deepjavalibrary/djl-demo/actions/runners/registration-token \
+          --fail \
+          | jq '.token' | tr -d '"' )
+          ./start_instance.sh action_gpu $token djl-demo
+    outputs:
+      gpu_instance_id: ${{ steps.create_gpu.outputs.action_gpu_instance_id }}
+
+  stop-runners:
+    if: always()
+    runs-on: [ self-hosted, scheduler ]
+    needs: [ create-gpu-runner, canary-test-cuda113 ]
+    steps:
+      - name: Stop all instances
+        run: |
+          cd /home/ubuntu/djl_benchmark_script/scripts
+          instance_id=${{ needs.create-gpu-runner.outputs.gpu_instance_id }}
+          ./stop_instance.sh $instance_id


### PR DESCRIPTION
Add gpu canary actions in parity with what we have in codebuild. 

Cuda 10.2 and Cuda 11.3 canaries are working fully in parity with what we have in codebuild.
- cuda 10.2 https://github.com/deepjavalibrary/djl-demo/actions/runs/2841970595
- cuda 11.3 https://github.com/deepjavalibrary/djl-demo/actions/runs/2842398240

Cuda 11.2 works except when testing `DJL_ENGINE=mxnet-native-cu112mkl`. The issue seems to be that we're not downloading/extracting the other .so files necessary from s3. This doesn't seem like an issue with the canary action, but I need to continue investigating that. The equivalent canary in codebuild hasn't been successful in a long time, so this might point to a real failure.

Failure for cuda 11.2 https://github.com/deepjavalibrary/djl-demo/runs/7794346123?check_suite_focus=true#step:8:806