### PR TITLE
update self-hosted canary tests

### DIFF
--- a/.github/workflows/canary-aarch64-linux.yml
+++ b/.github/workflows/canary-aarch64-linux.yml
@@ -22,7 +22,13 @@ jobs:
   canary-test-aarch64-linux:
     if: github.repository == 'deepjavalibrary/djl-demo'
     runs-on: [ self-hosted, aarch64 ]
-    container: amazonlinux:2
+    container:
+      image: amazonlinux:2
+      env:
+        AWS_REGION: us-east-1
+        DJL_STAGING: ${{github.event.inputs.repo-id}}
+        DJL_VERSION: ${{github.event.inputs.djl-version}}
+        PT_VERSION: ${{github.event.inputs.pt-version}}
     timeout-minutes: 30
     needs: create-aarch64-runner
     steps:

--- a/.github/workflows/canary-gpu-cuda-102.yml
+++ b/.github/workflows/canary-gpu-cuda-102.yml
@@ -25,6 +25,11 @@ jobs:
     container:
       image: nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04
       options: --gpus all --runtime=nvidia
+      env:
+        AWS_REGION: us-east-1
+        DJL_STAGING: ${{github.event.inputs.repo-id}}
+        DJL_VERSION: ${{github.event.inputs.djl-version}}
+        PT_VERSION: ${{github.event.inputs.pt-version}}
     timeout-minutes: 30
     needs: create-gpu-runner
     steps:

--- a/.github/workflows/canary-gpu-cuda-112.yml
+++ b/.github/workflows/canary-gpu-cuda-112.yml
@@ -25,6 +25,11 @@ jobs:
     container:
       image: nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu18.04
       options: --gpus all --runtime=nvidia
+      env:
+        AWS_REGION: us-east-1
+        DJL_STAGING: ${{github.event.inputs.repo-id}}
+        DJL_VERSION: ${{github.event.inputs.djl-version}}
+        PT_VERSION: ${{github.event.inputs.pt-version}}
     timeout-minutes: 30
     needs: create-gpu-runner
     steps:
@@ -45,7 +50,7 @@ jobs:
           rm -rf ~/.djl.ai
           DJL_ENGINE=mxnet-native-mkl ./gradlew clean run
           rm -rf ~/.djl.ai
-          DJL_ENGINE=mxnet-native-cu112mkl ./gradlew clean run
+          DJL_ENGINE=mxnet-native-cu112mkl MXNET_VERSION=1.9.1 ./gradlew clean run
           rm -rf ~/.djl.ai
       - name: Test PyTorch
         working-directory: canary

--- a/.github/workflows/canary-gpu-cuda-113.yml
+++ b/.github/workflows/canary-gpu-cuda-113.yml
@@ -25,6 +25,11 @@ jobs:
     container:
       image: nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu18.04
       options: --gpus all --runtime=nvidia
+      env:
+        AWS_REGION: us-east-1
+        DJL_STAGING: ${{github.event.inputs.repo-id}}
+        DJL_VERSION: ${{github.event.inputs.djl-version}}
+        PT_VERSION: ${{github.event.inputs.pt-version}}
     timeout-minutes: 30
     needs: create-gpu-runner
     steps:


### PR DESCRIPTION
Fixes the mxnet cu112 canary - uses version 1.9.1 which has the full jar file. https://github.com/deepjavalibrary/djl-demo/actions/runs/2848741447

I also tested with an update to the 1.9.0 binaries in staging repo aidjl-1195 and it works, so we can also publish an updated set of 1.9.0 binaries and test that here as well if we want (only cu112 is broken for mxnet right now). Here's the run using the staging repo contained the fixed 1.9.0 cu112 binaries https://github.com/deepjavalibrary/djl-demo/actions/runs/2849154026. 

Basic question: Does promoting the staging repo with fixed 1.9.0 binaries overwrite the current binaries in the release repo?