### PR TITLE
Update pytorch canary for cuda102 to 1.13.1

### DIFF
--- a/.github/workflows/canary-gpu.yml
+++ b/.github/workflows/canary-gpu.yml
@@ -62,7 +62,7 @@ jobs:
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.12.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.13.0 ./gradlew clean run
+          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=1.13.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true ./gradlew clean run
           rm -rf /root/.djl.ai/
@@ -70,7 +70,7 @@ jobs:
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=1.12.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=1.13.0 ./gradlew clean run
+          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=1.13.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu ./gradlew clean run
           rm -rf /root/.djl.ai/


### PR DESCRIPTION
Cuda102 for pytorch is currently using 1.13.0, but we have moved to 1.13.1.

Pytorch 1.13.x doesn't support Cuda102 anymore so the test just fetches cpu version. We're not updating 1.13.0 anymore.