### PR TITLE
Use GitHub Actions M1 runner

### DIFF
--- a/.github/workflows/canary-m1-mac.yml
+++ b/.github/workflows/canary-m1-mac.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   canary-test-arm64-osx:
     if: github.repository == 'deepjavalibrary/djl-demo'
-    runs-on: [ self-hosted, ARM64, macOS ]
+    runs-on: macos-latest-xlarge
     env:
       AWS_REGION: us-east-1
       DJL_STAGING: ${{github.event.inputs.repo-id}}


### PR DESCRIPTION
This switches the M1 canary to use the new GitHub actions hosted M1 runner.

Successful run: https://github.com/deepjavalibrary/djl-demo/actions/runs/7561989033/job/20591460285