### PR TITLE
Switch to cheaper M1

### DIFF
--- a/.github/workflows/canary-m1-mac.yml
+++ b/.github/workflows/canary-m1-mac.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   canary-test-arm64-osx:
     if: github.repository == 'deepjavalibrary/djl-demo'
-    runs-on: macos-latest-xlarge
+    runs-on: macos-14 #m1
     env:
       AWS_REGION: us-east-1
       DJL_STAGING: ${{github.event.inputs.repo-id}}


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

Run: https://github.com/deepjavalibrary/djl-demo/actions/runs/7715985234
