### PR TITLE
[ci] remove Quarkus test from nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,9 +33,3 @@ jobs:
       - name: Compile graalvm
         working-directory: graalvm
         run: ./mvnw package
-      - name: Compile Quarkus
-        working-directory: quarkus
-        run: |
-          cd example && ./mvnw package && cd ..
-          cd extension && mvn package install && cd ..
-          cd extension-example && ./mvnw package


### PR DESCRIPTION
Removing quarkus from nightly as it is no longer being actively maintained and now fails CI. Previous version of DJL will be available to support quarkus.
