### PR TITLE
[ci] Remove graavlm from nightly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,3 @@ jobs:
       - name: Compile Apache Camel
         working-directory: camel-djl
         run: mvn package
-      - name: Compile graalvm
-        working-directory: graalvm
-        run: ./mvnw package


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removing the graalvm nightly test from CI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
