### PR TITLE
[jupyter] Removed Comma Corrupting Image Classification Notebook

### DIFF
--- a/apache-spark/notebook/Image_Classification_Spark.ipynb
+++ b/apache-spark/notebook/Image_Classification_Spark.ipynb
@@ -28,7 +28,7 @@
     "import $ivy.`ai.djl:api:0.27.0`\n",
     "import $ivy.`ai.djl.spark:spark_2.12:0.27.0`\n",
     "import $ivy.`ai.djl.pytorch:pytorch-model-zoo:0.27.0`\n",
-    "import $ivy.`ai.djl.pytorch:pytorch-native-cpu-precxx11:2.1.1`\n",
+    "import $ivy.`ai.djl.pytorch:pytorch-native-cpu-precxx11:2.1.1`\n"
    ]
   },
   {


### PR DESCRIPTION
Changes 
- Removed comma that was corrupting notebook 

Methodology and Testing
- Attempted to open the notebook in VS Code, which resulted in a "not valid JSON" error.
- Opened the notebook in a text editor and identified the issue.
- Removed the offending comma.
- Re-opened the notebook in VS Code successfully without errors.