### PR TITLE
[canary][aarch64] install libatomic1 for sentencepiece

### DIFF
--- a/.github/workflows/canary-aarch64-linux.yml
+++ b/.github/workflows/canary-aarch64-linux.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Environment
         run: |
           yum -y update
-          yum install -y tar gzip libgomp
+          yum install -y tar gzip libgomp libatomic
           yum -y install java-17-amazon-corretto-devel
       - uses: taiki-e/checkout-action@v1
       - name: Test PyTorch


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


fixes canary for aarch64-linux sentencepiece by installing required libatomic. WF run https://github.com/deepjavalibrary/djl-demo/actions/runs/11872855959
