### PR TITLE
update djl version to 0.32.0-snapshot

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ systemProp.org.gradle.internal.http.connectionTimeout=60000
 # FIXME: Workaround gradle publish issue: https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
-djl_version=0.31.0-SNAPSHOT
+djl_version=0.32.0-SNAPSHOT
 commons_cli_version=1.8.0
 commons_csv_version=1.11.0
 commons_compress_version=1.26.1


### PR DESCRIPTION
*Issue #, if available:*

DJL Demo nightly canary has been failing because 0.31.0-snapshot expired. 
