### PR TITLE
[canary-gpu] remove pytorch 2.4.0 test from canary

### DIFF
--- a/.github/workflows/canary-aarch64-linux.yml
+++ b/.github/workflows/canary-aarch64-linux.yml
@@ -64,8 +64,6 @@ jobs:
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.3.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.4.0 ./gradlew clean run
-          rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.5.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu-precxx11 ./gradlew clean run
@@ -75,8 +73,6 @@ jobs:
           DJL_ENGINE=pytorch-native-cpu-precxx11 PT_VERSION=2.1.2 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu-precxx11 PT_VERSION=2.3.1 ./gradlew clean run
-          rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-cpu-precxx11 PT_VERSION=2.4.0 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu-precxx11 PT_VERSION=2.5.1 ./gradlew clean run
           rm -rf /root/.djl.ai/

--- a/.github/workflows/canary-al2.yml
+++ b/.github/workflows/canary-al2.yml
@@ -60,8 +60,6 @@ jobs:
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=2.3.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=2.4.0 ./gradlew clean run
-          rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=2.5.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu-precxx11 ./gradlew clean run
@@ -71,8 +69,6 @@ jobs:
           DJL_ENGINE=pytorch-native-cpu-precxx11 PT_VERSION=2.1.2 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu-precxx11 PT_VERSION=2.3.1 ./gradlew clean run
-          rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-cpu-precxx11 PT_VERSION=2.4.0 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu-precxx11 PT_VERSION=2.5.1 ./gradlew clean run
           rm -rf /root/.djl.ai/

--- a/.github/workflows/canary-gpu.yml
+++ b/.github/workflows/canary-gpu.yml
@@ -169,8 +169,6 @@ jobs:
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.3.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.4.0 ./gradlew clean run
-          rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.5.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=$PT_VERSION ./gradlew clean run
@@ -178,8 +176,6 @@ jobs:
           DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=2.1.2 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=2.3.1 ./gradlew clean run
-          rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=2.4.0 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_PRECXX11=true PYTORCH_VERSION=2.5.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
@@ -193,8 +189,6 @@ jobs:
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cu121 PT_VERSION=2.3.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-cu124 PT_VERSION=2.4.0 ./gradlew clean run
-          rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cu124 PT_VERSION=2.5.1 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cu124-precxx11 ./gradlew clean run
@@ -202,8 +196,6 @@ jobs:
           DJL_ENGINE=pytorch-native-cu121-precxx11 PT_VERSION=2.1.2 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cu121-precxx11 PT_VERSION=2.3.1 ./gradlew clean run
-          rm -rf /root/.djl.ai/
-          DJL_ENGINE=pytorch-native-cu124-precxx11 PT_VERSION=2.4.0 ./gradlew clean run
           rm -rf /root/.djl.ai/
           DJL_ENGINE=pytorch-native-cu124-precxx11 PT_VERSION=2.5.1 ./gradlew clean run
           rm -rf /root/.djl.ai/

--- a/.github/workflows/canary-m1-mac.yml
+++ b/.github/workflows/canary-m1-mac.yml
@@ -60,8 +60,6 @@ jobs:
           rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.3.1 ./gradlew clean run
           rm -rf $HOME/.djl.ai/
-          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.4.0 ./gradlew clean run
-          rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.5.1 ./gradlew clean run
           rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu ./gradlew clean run
@@ -71,8 +69,6 @@ jobs:
           DJL_ENGINE=pytorch-native-cpu PT_VERSION=2.1.2 ./gradlew clean run
           rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu PT_VERSION=2.3.1 ./gradlew clean run
-          rm -rf $HOME/.djl.ai/
-          DJL_ENGINE=pytorch-native-cpu PT_VERSION=2.4.0 ./gradlew clean run
           rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu PT_VERSION=2.5.1 ./gradlew clean run
           rm -rf $HOME/.djl.ai/

--- a/.github/workflows/canary-ubuntu.yml
+++ b/.github/workflows/canary-ubuntu.yml
@@ -79,8 +79,6 @@ jobs:
           rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.3.1 ./gradlew clean run
           rm -rf $HOME/.djl.ai/
-          DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.4.0 ./gradlew clean run
-          rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-auto PYTORCH_VERSION=2.5.1 ./gradlew clean run
           rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu ./gradlew clean run
@@ -90,8 +88,6 @@ jobs:
           DJL_ENGINE=pytorch-native-cpu PT_VERSION=2.1.2 ./gradlew clean run
           rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu PT_VERSION=2.3.1 ./gradlew clean run
-          rm -rf $HOME/.djl.ai/
-          DJL_ENGINE=pytorch-native-cpu PT_VERSION=2.4.0 ./gradlew clean run
           rm -rf $HOME/.djl.ai/
           DJL_ENGINE=pytorch-native-cpu PT_VERSION=2.5.1 ./gradlew clean run
           rm -rf $HOME/.djl.ai/


### PR DESCRIPTION

The below are the pytorch engine versions we officially publish to support various cuda versions. 
- PT 1.13.1 is for PT 1.x support, and CUDA 11.x support
- PT 2.1.2 is for Neuron support (latest supported version on neuron)
- PT 2.3.1 is for CUDA 12.1 support
- PT 2.5.1 is for CUDA 12.4 support

So, removing 2.4.0 from canaries as dont publish it anymore. 
