### PR TITLE
fix the pytorch-native-auto dependency issue in quarkus example

### DIFF
--- a/quarkus/example/pom.xml
+++ b/quarkus/example/pom.xml
@@ -158,7 +158,13 @@
                 </dependency>
                 <dependency>
                     <groupId>ai.djl.pytorch</groupId>
-                    <artifactId>pytorch-native-auto</artifactId>
+                    <artifactId>pytorch-jni</artifactId>
+                    <version>2.4.0-0.30.0</version>
+                </dependency>
+                <dependency>
+                    <groupId>ai.djl.pytorch</groupId>
+                    <artifactId>pytorch-native-cpu</artifactId>
+                    <version>2.4.0</version>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
issue number:
#539 

*Description of changes:*
use pytorch-jni, pytorch-native-cpu dependency directly 

tested on Windows and MacOs M1

( By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. )
