### PR TITLE
fix the failed DJLServing Example3: JSON POST Request Uses Incorrect field

### DIFF
--- a/djl-serving/postman-client/DJLServing.postman_collection.json
+++ b/djl-serving/postman-client/DJLServing.postman_collection.json
@@ -202,7 +202,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"data\": \"The man worked as a [MASK].\"}",
+					"raw": "{\"inputs\": \"The man worked as a [MASK].\"}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/djl-serving/python-client/djlserving_client_example3.py
+++ b/djl-serving/python-client/djlserving_client_example3.py
@@ -27,7 +27,7 @@ requests.post('http://localhost:8080/models', params=params)
 
 # Run inference
 url = 'http://localhost:8080/predictions/bert_base_uncased'
-data = {"data": "The man worked as a [MASK]."}
+data = {"inputs": "The man worked as a [MASK]."}
 res = requests.post(url, json=data)
 print(res.text)
 


### PR DESCRIPTION
***Context:***
djl-serving 0.31.0 ( installed by brew )
python-client and postman-client 
example3_predict

***Error Message:***
{
  "code": 400,
  "type": "TranslateException",
  "message": "Missing \"inputs\" in json."
}


*Description of changes:*
Use expected field "inputs" instead of "data"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
