### PR TITLE
upgrade javacpp version to 1.5.11 to fix the TF engine init failure in Graalvm example

### DIFF
--- a/graalvm/pom.xml
+++ b/graalvm/pom.xml
@@ -103,13 +103,13 @@
                 <dependency>
                     <groupId>org.bytedeco</groupId>
                     <artifactId>javacpp</artifactId>
-                    <version>1.5.4</version>
+                    <version>1.5.11</version>
                     <classifier>macosx-x86_64</classifier>
                 </dependency>
                 <dependency>
                     <groupId>org.bytedeco</groupId>
                     <artifactId>javacpp</artifactId>
-                    <version>1.5.4</version>
+                    <version>1.5.11</version>
                 </dependency>
                 <dependency>
                     <groupId>ai.djl.tensorflow</groupId>


### PR DESCRIPTION
*Issue #, if available:*
#545

*Description of changes:*
DJL Version: 0.30.0
JavaCPP Version: 1.5.7

DJL throws a `NoSuchMethodError` when attempting to load the TensorFlow engine because the required method `Loader.loadProperties(boolean)` is not present in JavaCPP version 1.5.7.

The TensorFlow engine should initialize successfully without any errors, allowing DJL to perform TensorFlow-based operations.

JavaCPP 1.5.11 works 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
