### PR TITLE
Fix pip installation command in huggingface hybrid README

### DIFF
--- a/huggingface/hybrid/README.md
+++ b/huggingface/hybrid/README.md
@@ -19,7 +19,7 @@ Go into the `model` directory and run the following command to download Huggingf
 ```
 cd models
 
-pip install requirements.txt
+pip install -r requirements.txt
 python download_models.py
 ```
 


### PR DESCRIPTION
*Description of changes:*
Corrected the installation command in README from pip install requirements.txt to pip install -r requirements.txt.

This ensures that pip installs all packages specified in the requirements.txt file

pip install requirements.txt  leads to 
```
ERROR: Could not find a version that satisfies the requirement requirements.txt (from versions: none)
HINT: You are attempting to install a package literally named "requirements.txt" (which cannot exist). Consider using the '-r' flag to install the packages listed in requirements.txt
ERROR: No matching distribution found for requirements.txt
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
