### PR TITLE
Fix docker build, ensure packaging module is installed before jupyter…

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 RUN apt-get update || true
 RUN apt-get install -y openjdk-11-jdk-headless
 RUN apt-get install -y python3-pip git
-RUN pip3 install jupyter
+RUN pip3 install packaging jupyter
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y locales \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \


### PR DESCRIPTION


*Issue #, if available:*
#550

*Description of changes:*
The Docker build was failing at the `pip3 install jupyter` step due to a missing `packaging` module, which is required during the installation of some jupyter dependencies like pyzmq.

This commit adds an explicit installation of `packaging` before installing jupyter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
