### PR TITLE
SageMaker notebook failed show Java Kernel in selection list 

### DIFF
--- a/aws/sagemaker/notebook/README.md
+++ b/aws/sagemaker/notebook/README.md
@@ -10,7 +10,7 @@ We will use [IJava](https://github.com/SpencerPark/IJava) Kernel for Java API. Y
 
 ```bash
 curl -L https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip -o ijava-kernel.zip &> /dev/null
-unzip -q ijava-kernel.zip -d ijava-kernel && cd ijava-kernel && python3 install.py --sys-prefix &> /dev/null
+unzip -oq ijava-kernel.zip -d ijava-kernel && cd ijava-kernel && python3 install.py --user &> /dev/null
 jupyter kernelspec list
 ```
 


### PR DESCRIPTION
Description:
Using python3 install.py --sys-prefix according to the README installs the kernel under: $CONDA_PREFIX/share/jupyter/kernels/. (/home/ec2-user/anaconda3/envs/python3/share/jupyter/kernels/)

However, in SageMaker notebook instances (e.g., notebook-al2-v2 and notebook-al2-v3) the Java kernel does not appear in the kernel selection list. **Even after waiting long enough and refreshing many times.** java kernel has not been able to show up in the selection menu and connect to it. 

If use python3 install.py --user , keneral will soon be available in the selection menu. 

*Description of changes:*
1. Switch to: python3 install.py --user 
This installs the kernel into:  ~/.local/share/jupyter/kernels/

2. use unzip -op instead of -p to prevent failures due to repeated script executions.

Tested with notebook-al2-v2 and notebook-al2-v3 instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
