### PR TITLE
[canary] remove ubuntu20.04 canary due to gh action runner deprecation

### DIFF
--- a/.github/workflows/canary-ubuntu.yml
+++ b/.github/workflows/canary-ubuntu.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
     env:
       AWS_REGION: us-east-1
       DJL_STAGING: ${{github.event.inputs.repo-id}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
